### PR TITLE
Add import_paths to .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,5 +5,5 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_root = "github.com/vinhut/gapura"
+  import_paths = ["github.com/vinhut/gapura"]
   dependencies_vendored = true


### PR DESCRIPTION
`import_root` is only required when there are multiple import paths in a repo (a monorepo). `import_paths` is always required. Ref: https://deepsource.io/docs/analyzer/go.html#import-paths